### PR TITLE
feat: Add `docs` input source, start converting documentation

### DIFF
--- a/packages/parsec/src/parsec/docs/literals.clj
+++ b/packages/parsec/src/parsec/docs/literals.clj
@@ -1,0 +1,126 @@
+;; Copyright 2022 Expedia, Inc.
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     https://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns parsec.docs.literals)
+
+(def tokens
+  '({:name "null"
+     :type "literal"
+     :syntax ["null"]
+     :description ["The keyword \"null\" represents the absence of value.
+                     
+                     Generally, operators and functions applied to null values tend to return null."]
+     :examples [{:q "set @x = null"}]}
+    {:name "true"
+     :type "literal"
+     :syntax ["true"]
+     :description ["The keyword \"true\" represents the boolean truth value. It can be used in equality/inequality expressions, or assigned to columns or variables.
+                              
+                    Non-zero numbers are considered true from a boolean perspective."]
+     :examples [{:q "set @truth = true"}
+                {:description "Non-zero numbers are considered true from a boolean perspective"
+                 :q "set @truth = (1 == true)"}]
+     :related ["literal:false"]}
+    {:name "false"
+     :type "literal"
+     :syntax ["false"]
+     :description "
+                The keyword \"false\" represents the boolean falsehood value It can be used in equality/inequality expressions, or assigned to columns or variables.
+                     
+                Zero numbers are considered false from a boolean perspective."
+     :examples [{:q "set @truth = false"}
+                {:description "Zero numbers are considered false from a boolean perspective"
+                 :q "set @truth = (0 == false)"}]
+     :related ["literal:true"]}
+    {:name "\"number\""
+     :type "literal"
+     :syntax ["Regex: /[-+]?(0(.\\d*)?|([1-9]\\d*.?\\d*)|(.\\d+))([Ee][+-]?\\d+)?/"
+              "Regex: /[-+]?(0(.\\d*)?|([1-9]\\d*.?\\d*)|(.\\d+))([Ee][+-]?\\d+)?[%]/"]
+     :returns "number"
+     :description ["Internally, Parsec supports the full range of JVM primitive numbers, as well as BigInteger, BigDecimal, and Ratios.
+                    
+                    A number that ends with a percent sign indicates a percentage.  The numerical value of the number will be divided by 100."]
+     :examples [{:description "Integer"
+                 :q "set @x = 100"}
+                {:description "Floating-point (double) number"
+                 :q "set @y = 3.141592"}
+                {:description "Scientific-notation"
+                 :q "set @a = 1.234e50, @b = 1.234e-10"}
+                {:description "Percents"
+                 :q "set @a = 50%, @b = 12 * @a"}]}
+    {:name "\"identifier\""
+     :type "literal"
+     :syntax ["Regex: /[a-zA-Z_][a-zA-Z0-9_]*/"
+              "Regex: /`[^`]+`/"]
+     :description ["Identifiers are alpha-numeric strings used to reference columns in the current dataset.
+                     
+                    There are two possible forms for identifiers: the primary form must start with a letter or underscore, and may only contain letters, numbers, or underscores. The alternate form uses two backtick (`) characters to enclose any string of characters, including spaces or special characters (except backticks).
+                     
+                    Identifiers are case-sensitive."]
+     :examples [{:description "Primary form"
+                 :q "input mock | col6 = col5"}
+                {:description "Backtick form allows spaces and special characters"
+                 :q "input mock | stats `avg $` = mean(col1 * col2)"}]}
+    {:name "\"variable\""
+     :type "literal"
+     :syntax ["Regex: /@[a-zA-Z0-9_]+[']?/"]
+     :description ["Variables are alpha-numeric strings prefixed with an at symbol (@). A trailing single-quote character is allowed, representing the prime symbol.
+                    
+                     Unlike identifiers, variables are not associated with rows in the current dataset. Variables are stored in the context and available throughout the evaluation of a query (once they have been set)."]
+     :examples [{:description "Setting a variable"
+                 :q "set @fruit = \" banana \""}
+                {:description "Storing a calculated value in a variable"
+                 :q "input mock | set @x=mean(col1) | y = col1 - @x"}
+                {:description "Prime variables"
+                 :q "input mock | set @x = mean(col1), @x' = @x^2 | stats x=@x, y=@x\"\""}]
+     :related ["statement:set"]}
+    {:name "\"string\""
+     :type "literal"
+     :syntax ["TBD"]
+     :returns "string"
+     :description ["Strings can be created by wrapping text in single or double-quote characters. The quote character can be escaped inside a string using \\\" or \\'.
+                    
+                     Strings can also be created using a triple single-quote, which has the benefit of allowing single and double quote characters to be used unescaped.  Naturally, a triple single quote can be escaped inside a string using \\'''.
+                    
+                     Standard escape characters can be used inside a string, e.g.: \\n, \\r, \\t, \\\\, etc."]
+     :examples [{:description "Single-quoted string"
+                 :q "set @msg = 'hello world'"}
+                {:description "Double-quoted string"
+                 :q "set @msg = \"hello world\""}
+                {:description "Double-quoted string with escaped characters inside"
+                 :q "set @msg = \" \\\"I can't imagine\\\", said the Princess. "}
+                {:description "Triple-quoted string"
+                 :q "set @query = '''Parsec query:\t 'set @msg = \" hello world \"'''"}]}
+    {:name "\"list\""
+     :type "literal"
+     :syntax ["[expr1, expr2, ... ]"]
+     :description ["Lists can be created using the tolist() function or with a list literal: [expr1, expr2, ...]."]
+     :examples [{:description "Creating a list with hard-coded values"
+                 :q "set @list = [1, 2, 3]"}
+                {:description "Creating a list using expressions for each value"
+                 :q "input mock | x = [col1, col2, col3 + col4]"}]
+     :related ["function:tolist"]}
+    {:name "\"map\""
+     :type "literal"
+     :syntax ["{ key1: expr1, key2: expr2, ... }"]
+     :description ["Maps can be created using the tomap() function or with a map literal: {key1: expr1, key2: expr2, ...}."]
+     :examples [{:description "Creating a map with hard-coded values"
+                 :q "set @map = { a: 1, b: 2 }"}
+                {:description "Creating a map with strings for keys"
+                 :q "set @map = { " a ": 1, " b ": 2 }"}
+                {:description "Creating a map using expressions for each value"
+                 :q "input mock | x = { col1: col1, col2: col2 }"}
+                {:description "Aggregating into a map"
+                 :q "input mock | stats x = { min: min(col1), max: max(col1) }"}]
+     :related ["function:tomap"]}))

--- a/packages/parsec/src/parsec/docs/operators.clj
+++ b/packages/parsec/src/parsec/docs/operators.clj
@@ -1,0 +1,195 @@
+;; Copyright 2022 Expedia, Inc.
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     https://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns parsec.docs.operators)
+
+(def tokens
+  '({:name "-"
+     :altName "negation"
+     :type "operator"
+     :subtype "arithmetic"
+     :syntax ["-:expression"]
+     :returns "number"
+     :description ["The negation operator toggles the sign of a number: making positive numbers negtive and negative numbers positive."
+                   "Returns null if the expression is null"
+                   "Since numbers can be parsed with a negative sign, this operator will only be used when preceding a non-numerical expression in the query, e.g. \"-x\" or \"-cos(y)\"."]
+     :examples [{:description "Negating a column"
+                 :q "input mock | x = -col1"}]}
+    {:name "+"
+     :altName "addition"
+     :type "operator"
+     :subtype "arithmetic"
+     :syntax [":expression1 + :expression2"]
+     :returns "number"
+     :description ["The addition operator adds one number to another, or concatenates two strings. If one operand is a string, the other will be coerced into a string, and concatenated."
+                   "Returns null if either expression is null."]
+     :examples [{:description "Adding numbers"
+                 :q "input mock | x = col1 + col2"}
+                {:description "Concatenating strings"
+                 :q "input mock | x = \"hello\" + \" \" + \"world\""}]}
+    {:name "-"
+     :altName "subtraction"
+     :type "operator"
+     :subtype "arithmetic"
+     :syntax [":expression1 - :expression2"]
+     :returns "number"
+     :description ["The subtraction operator subtracts one number from another, or creates an interval between two DateTimes."
+                   "Returns null if either expression is null."]
+     :examples [{:description "Subtracting numbers"
+                 :q "input mock | x = col1 - col2"}
+                {:description "Subtracting DateTimes to create an interval"
+                 :q "input mock | x = inminutes(now() - today())"}]}
+    {:name "*"
+     :altName "multiplication"
+     :type "operator"
+     :subtype "arithmetic"
+     :syntax [":expression1 * :expression2"]
+     :returns "number"
+     :description ["The multiplication operator multiplies two numbers together."
+                   "Returns null if either expression is null."
+                   "Multiplying by any non-zero number by infinity gives infinity, while the result of zero times infinity is NaN."]
+     :examples [{:description "Multiplying numbers"
+                 :q "input mock | x = col1 * col2"}
+                {:description "Multiplying by infinity"
+                 :q "input mock | x = col1 * infinity()"}]}
+    {:name "/"
+     :altName "division"
+     :type "operator"
+     :subtype "arithmetic"
+     :syntax [":expression1 / :expression2"]
+     :returns "number"
+     :description ["The division operator divides the value of one number by another. If the value is not an integer, it will be stored as a ratio or floating-point number."
+                   "Returns null if either expression is null."
+                   "Dividing a positive number by zero yields infinity, and dividing a negative number by zero yields -infinity. If both numeric expressions are zero, the result is NaN."]
+     :examples [{:description "Dividing numbers"
+                 :q "input mock | x = col1 / col2"}
+                {:description "Dividing by zero gives infinity"
+                 :q "input mock | x = col1 / 0, isInfinity = isinfinite(x)"}]}
+    {:name "mod"
+     :type "operator"
+     :subtype "arithmetic"
+     :syntax [":expression1 mod :expression2"]
+     :returns "number"
+     :description ["The modulus operator finds the amount by which a dividend exceeds the largest integer multiple of the divisor that is not greater than that number. For positive numbers, this is equivalent to the remainder after division of one number by another."
+                   "Returns null if either expression is null."
+                   "By definition, 0 mod N yields 0, and N mod 0 yields NaN."]
+     :examples [{:q "input mock | x = col2 mod col1"}
+                {:description "Modulus by zero is NaN"
+                 :q "input mock | x = col1 mod 0, isNaN = isnan(x)"}]}
+    {:name "^"
+     :altName "exponent"
+     :type "operator"
+     :subtype "arithmetic"
+     :syntax [":expression1 ^ :expression2"]
+     :returns "number"
+     :description ["The exponent operator raises a number to the power of another number."
+                   "Returns null if either expression is null."
+                   "By definition, N^0 yields 1."]
+     :examples [{:q "input mock | x = col1 ^ col2"}]}
+    {:name "and"
+     :type "operator"
+     :subtype "logical"
+     :syntax [":expression1 and :expression2" ":expression1 && :expression2"]
+     :returns "boolean"
+     :description ["The logical and operator compares the value of two expressions and returns true if both values are true, else false."
+                   "Returns null if either expression is null."]
+     :examples [{:q "input mock | x = (true and true)"}
+                {:q "input mock | x = (true && false)"}
+                {:q "input mock | x = isnumber(col1) and col1 > 3"}
+                {:q "input mock | x = col1 > 1 and null"}]}
+    {:name "or"
+     :type "operator"
+     :subtype "logical"
+     :syntax [":expression1 or :expression2" ":expression1 || :expression2"]
+     :returns "boolean"
+     :description ["The logical or operator compares the value of two expressions and returns true if at least one value is true, else false."
+                   "Returns null if either expression is null."]
+     :examples [{:q "input mock | x = (true or false)"}
+                {:q "input mock | x = (false || false)"}
+                {:q "input mock | x = col3 == 3 or col1 > 3"}
+                {:q "input mock | x = col1 > 1 or null"}]}
+    {:name "not"
+     :type "operator"
+     :subtype "logical"
+     :syntax ["not :expression" "!:expression"]
+     :returns "boolean"
+     :description ["The logical negation operator returns true if the boolean value of :expression is false, else it returns false."
+                   "Returns null if the expression is null."]
+     :examples [{:q "input mock | x = not true"}
+                {:q "input mock | x = !false"}
+                {:q "input mock | x = !null"}]}
+    {:name "xor"
+     :type "operator"
+     :subtype "logical"
+     :syntax [":expression1 xor :expression2" ":expression1 ^^ :expression2"]
+     :returns "boolean"
+     :description ["The logical xor operator compares the value of two expressions and returns true if exactly one value is true, else false."
+                   "Returns null if either expression is null."]
+     :examples [{:q "input mock | x = (true xor false)"}
+                {:q "input mock | x = (false ^^ false)"}
+                {:q "input mock | x = true xor null"}]}
+    {:name "=="
+     :altName "equals"
+     :type "operator"
+     :subtype "equality"
+     :syntax [":expression1 == :expression2"]
+     :returns "boolean"
+     :description ["The equality operator compares the value of two expressions and returns true if they are equal, else false."]
+     :examples [{:q "input mock | x = (col1 == col2)"}
+                {:q "input mock | filter col1 == 1 "}]}
+    {:name "!="
+     :altName "unequals"
+     :type "operator"
+     :subtype "equality"
+     :syntax [":expression1 != :expression2"]
+     :returns "boolean"
+     :description ["The inequality operator compares the value of two expressions and returns true if they are unequal, else false."]
+     :examples [{:q "input mock | x = (col1 != col2)"}
+                {:q "input mock | filter col1 != 1 "}]}
+    {:name ">"
+     :altName "greater than"
+     :type "operator"
+     :subtype "equality"
+     :syntax [":expression1 > :expression2"]
+     :returns "boolean"
+     :description ["The greater-than operator returns true if :expression1 is strictly greater than :expression2, else false."]
+     :examples [{:q "input mock | x = (col1 > col2)"}
+                {:q "input mock | filter col1 > 1 "}]}
+    {:name "<"
+     :altName "less than"
+     :type "operator"
+     :subtype "equality"
+     :syntax [":expression1 < :expression2"]
+     :returns "boolean"
+     :description ["The less-than operator returns true if :expression1 is strictly less than :expression2, else false."]
+     :examples [{:q "input mock | x = (col1 < col2)"}
+                {:q "input mock | filter col1 < 1 "}]}
+    {:name ">="
+     :altName "greater or equal"
+     :type "operator"
+     :subtype "equality"
+     :syntax [":expression1 >= :expression2"]
+     :returns "boolean"
+     :description ["The greater than or equal operator returns true if :expression1 is greater than or equal to :expression2, else false."]
+     :examples [{:q "input mock | x = (col1 >= col2)"}
+                {:q "input mock | filter col1 >= 1 "}]}
+    {:name "<="
+     :altName "less or equal"
+     :type "operator"
+     :subtype "equality"
+     :syntax [":expression1 <= :expression2"]
+     :returns "boolean"
+     :description ["The less than or equal operator returns true if :expression1 is less than or equal to :expression2, else false."]
+     :examples [{:q "input mock | x = (col1 <= col2)"}
+                {:q "input mock | filter col1 <= 1 "}]}))

--- a/packages/parsec/src/parsec/docs/statements.clj
+++ b/packages/parsec/src/parsec/docs/statements.clj
@@ -1,0 +1,328 @@
+;; Copyright 2022 Expedia, Inc.
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     https://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns parsec.docs.statements)
+
+(def tokens
+  '({:name "input"
+     :type "statement"
+     :description ['The input statement loads a dataset from various possible sources. Different input sources are available, like mock, jdbc, and http. Each source has various options for configuring it. If a dataset is already in the pipeline, it will be replaced.']
+     :examples [{:description "Loading mock data from the built-in mock input"
+                 :q "input mock"}
+                {:description "Several named datasets are included in the mock input"
+                 :q "input mock name=\"chick-weight\""}]
+     :related ["input:mock", "input:datastore", "input:graphite", "input:http",  "input:influxdb", "input:jdbc", "input:mongodb", "input:smb", "input:s3"]}
+    {:name "output"
+     :type "statement"
+     :syntax ["output name=\":name\" :options"
+              "output ignore"]
+     :description ["Outputs the current dataset. This is useful when executing multiple queries at once, in order to return multiple named datasets in the result. Any query which does not end in either an output or temp statement will have an implicit output added.  To prevent this, use \"output ignore\"."
+                   "If the option \"temporary=true\" is added, the dataset will be stored in the datastore but not returned with the final query results. This is useful for intermediate datasets."
+                   "If no name is provided, an automatic name will be generated using the index of the dataset in the data store."
+                   "By default, the dataset is output to the datastore, in the execution context.  There is a \"type\" option to change the default destination."
+                   "Available output types: \"datastore\" (default), \"ignore\"."]
+     :examples [{:description "Returning two named datasets"
+                 :q "input mock | output name=\"ds1\";\ninput mock | output name=\"ds2\""}
+                {:description "Creating a temporary dataset"
+                 :q "input mock | output name=\"ds1\" temporary=true;\ninput mock | output name=\"ds2\""}
+                {:description "Ignoring the current dataset"
+                 :q "input mock | output ignore"}
+                {:description "Explicit options"
+                 :q "input mock | output name=\"results\" temporary=false type=\"datastore\" auto=false"}]
+     :related ["statement:temp"]}
+    {:name "temp"
+     :type "statement"
+     :syntax ["temp :name"]
+     :description ["The temp statement stores the current dataset in the datastore as a temporary dataset. This means the dataset will be accessible to the rest of the queries, but will not be output as a result dataset."
+                   "The temp statement is a shortcut for \"output name='name' temporary=true\"."]
+     :examples [{:q "input mock | temp ds1; input datastore name=\"ds1\""}]
+     :related ["statement:output"]}
+    {:name "head"
+     :type "statement"
+     :syntax ["head"
+              "head :number"]
+     :description ["Filters the current dataset to the first row or first :number of rows."]
+     :examples [{:description "Just the first row"
+                 :q "input mock | head"}
+                {:description "First twenty rows"
+                 :q "input mock name=\"thurstone\" | head 20"}]
+     :related ["statement:tail"]}
+    {:name "tail"
+     :type "statement"
+     :syntax ["tail"
+              "tail :number"]
+     :description ["Filters the current dataset to the last row or last :number of rows."]
+     :examples [{:description "Just the tail row"
+                 :q "input mock | tail"}
+                {:description "Last twenty rows"
+                 :q "input mock name=\"thurstone\" | tail 20"}]
+     :related ["statement:head"]}
+    {:name "select"
+     :type "statement"
+     :syntax ["select :identifier [, :identifier, ...]"]
+     :description ["Selects the specified columns in each row and removes all other columns."]
+     :examples [{:description "Creating and selecting a new column"
+                 :q "input mock | sum = col1 + col2 | select sum"}
+                {:description "Selecting several columns"
+                 :q "input mock name=\"survey\" | select age, income, male"}]
+     :related ["statement:unselect"]}
+    {:name "unselect"
+     :type "statement"
+     :syntax ["unselect :identifier [, :identifier, ...]"]
+     :description ["Removes the specified columns in each row, leaving the remaining columns."]
+     :examples [{:description "Unselecting a specific column"
+                 :q "input mock | unselect col3"}
+                {:description "Unselecting several columns"
+                 :q "input mock name=\"survey\" | unselect n, intercept, outmig, inmig | head 20"}]
+     :related ["statement:select"]}
+    {:name "filter"
+     :type "statement"
+     :syntax ["filter :expression"]
+     :description ["Filters rows in the current dataset by a predicate. Rows for which the predicate evaluates to true will be kept in the dataset."
+                   "This is the inverse of the remove statement."]
+     :examples [{:description "Simple predicate"
+                 :q "input mock name=\"chick-weight\" | filter Chick == 1"}
+                {:description "Predicate with multiple conditions"
+                 :q "input mock name=\"chick-weight\" | filter Chick == 1 and Time == 0"}]
+     :related ["statement:remove"]}
+    {:name "remove"
+     :type "statement"
+     :syntax ["remove :expression"]
+     :description ["Removes rows in the current dataset by a predicate. Rows for which the predicate evaluates to true will be removed from the dataset."
+                   "This is the inverse of the filter statement."]
+     :examples [{:description "Simple predicate"
+                 :q "input mock name=\"chick-weight\" | remove Chick == 1"}
+                {:description "Predicate with multiple conditions"
+                 :q "input mock name=\"chick-weight\" | remove Chick > 1 or Time > 0"}]
+     :related ["statement:filter"]}
+    {:name "reverse"
+     :type "statement"
+     :syntax ["reverse"]
+     :description ["Reverses the order of the current dataset. That is, sorts the rows by the current index, descending."]
+     :examples [{:q "input mock name=\"iran-election\" | reverse"}]}
+    {:name "union"
+     :type "statement"
+     :syntax ["union :query"
+              "union (all|distinct) :query"
+              "union (all|distinct) (:query)"]
+     :description ["Combines the rows of the current dataset with those from another sub-query.  If the sub-query is longer than a single input statement, it should be wrapped in parentheses to differentiate from the parent query."
+                   "The argument ALL or DISTINCT determines which rows are included in the dataset.  DISTINCT returns only unique rows, whereas ALL includes all rows from both datasets, even if they are identical.  The default behavior is DISTINCT."
+                   "Rows from the first dataset will preceed those from the sub-query."]
+     :examples [{:description "Performs a distinct union by default"
+                 :q "input mock | union input mock"}
+                {:description "Optionally unions all rows"
+                 :q "input mock | union all input mock"}
+                {:description "Wrap multi-statement sub-queries in parentheses"
+                 :q "input mock | union (input mock | col1 = col2 + col3)"}]}
+    {:name "distinct"
+     :type "statement"
+     :syntax ["distinct"]
+     :description ["Filters the current dataset to the set of unique rows.  A row is unique if there is no other row in the dataset with the same columns and values."
+                   "Rows in the resulting dataset will remain in the same order as in the original dataset."]
+     :examples [{:q "input mock | select col3 | distinct"}
+                {:q "input mock | union all input mock | distinct"}]}
+    {:name "rownumber"
+     :type "statement"
+     :syntax ["rownumber"
+              "rownumber :identifier"]
+     :description ["Assigns the current row number in the dataset to a column. If a column identifier is not provided, the default value of " _index " will be used."
+                   "The rank() function implements similar functionality as a function, but has greater overhead and is only preferable when being used in an expression."]
+     :examples [{:q "input mock | rownumber"}
+                {:q "input mock | rownumber rowNumber"}
+                {:q "input mock name=\"chick-weight\" | rownumber rank1 | rank2 = rank() | equal = rank1 == rank2 | stats count = count(*) by equal"}]
+     :related ["function:rank"]}
+    {:name "sort"
+     :type "statement"
+     :syntax ["sort :identifier"
+              "sort :identifier (asc|desc)"
+              "sort :identifier (asc|desc) [, :identifier (asc|desc), ...]"]
+     :description ["Sorts the current dataset by one or more columns.  Each column can be sorted either in ascending (default) or descending order"]
+     :examples [{:q "input mock | sort col1"}
+                {:q "input mock | sort col1 asc"}
+                {:q "input mock | sort col1 asc, col2 desc"}]}
+    {:name "def"
+     :type "statement"
+     :syntax ["def :function-name = (:arg, :arg, ..) -> :expression, ..."]
+     :description ["Defines one or more user-defined functions and saves into the current query context. Functions can take any number of arguments and return a single value."
+                   "Def can be used at any point in the query, even before input. user-defined functions must be defined before they are invoked, but can be used recursively or by other functions."
+                   "It is not possible to override built-in Parsec functions, but user-defined functions can be redefined multiple times."]
+     :examples [{:description "Calculate the distance between two points"
+                 :q "def distance = (p1, p2) -> \n    sqrt((index(p2, 0) - index(p1, 0))^2 + (index(p2, 1) - index(p1, 1))^2)\n| set @d = distance([0,0],[1,1])"}
+                {:description "Calculate the range of a list"
+                 :q "def range2 = (list) -> lmax(list) - lmin(list)\n| set @range = range2([8, 11, 5, 14, 25])"}
+                {:description "Calculate the factorial of a number using recursion"
+                 :q "def factorial = (n) -> if(n == 1, 1, n*factorial(n-1))\n| set @f9 = factorial(9)"}
+                {:description "Calculate the number of permutations of n things, taken r at a time"
+                 :q "def factorial = (n) -> if(n == 1, 1, n*factorial(n-1)), permutations = (n, r) -> factorial(n) / factorial(n - r)\n| set @p = permutations(5, 2)"}]
+     :related ["symbol:->:function"]}
+    {:name "set"
+     :type "statement"
+     :syntax ["set @var1 = :expression, [@var2 = :expression, ...]"
+              "set @var1 = :expression, [@var2 = :expression, ...] where :predicate"]
+     :description ["Sets one or more variables in the context. As variables are not row-based, the expression used cannot reference individual rows in the data set. However, it can use aggregate functions over the data set. An optional predicate argument can be used to filter rows before the aggregation."
+                   "Set can be used at any point in the query, even before input"
+                   "Variables are assigned from left to right, so later variables can reference previously assigned variables."
+                   "Existing variables will be overridden."]
+     :examples [{:description "Set a constant variable"
+                 :q "set @plank = 6.626070040e-34"}
+                {:description "Set several dependent variables"
+                 :q "set @inches = 66, @centimeters_per_inch = 2.54, @centimeters = @inches * @centimeters_per_inch"}
+                {:description "Calculate an average and use later in the query"
+                 :q "input mock | set @avg = avg(col1) | filter col1 > @avg"}]
+     :related ["literal:\"variable\""]}
+    {:name "rename"
+     :type "statement"
+     :syntax ["rename :column=:oldcolumn, ..."
+              "rename :column=:oldcolumn, ... where :predicate"]
+     :description ["Renames one or more columns in the dataset."
+                   "If a predicate is specified, the rename will apply only to rows satisfying the predicate."]
+     :examples [{:q "input mock | rename day = col1, sales = col2, bookings = col3, numberOfNights = col4"}
+                {:description "With predicate"
+                 :q "input mock | rename col5 = col1 where col1 < 2"}]}
+    {:name "assignment"
+     :type "statement"
+     :syntax [":column=:expr, ..."
+              ":column=:expr, ... where :predicate"]
+     :description ["Assigns one or more columns to each row in the dataset, by evaluating an expression for each row. Assignments are made from left to right, so it is possible to reference previously assigned columns in the same assignemnt statement."
+                   "If a predicate is specified, the assignments will apply only to rows satisfying the predicate."]
+     :examples [{:q "input mock | ratio = col1 / col2"}
+                {:description "With predicate"
+                 :q "input mock | col1 = col1 + col2 where col1 < 3"}
+                {:description "With multiple assignments"
+                 :q "input mock | ratio = col1 / col2, col5 = col3 * ratio"}]}
+    {:name "stats"
+     :type "statement"
+     :syntax ["stats :expression, ... "
+              "stats :expression, ... by :expression, ..."]
+     :description ["Calculates one or more aggregate expressions across the dataset, optionally grouped by one or more expressions.  The resulting dataset will have a single row for each unique value(s) of the grouping expressions."
+                   "Grouping expressions will be evaluated for each row, and the values used to divide the datasets into subsets.  Each grouping expression will become a column in the resulting dataset, containing the values for that subset.  If no grouping expressions are provided, the aggregations will run across the entire dataset."]
+     :examples [{:q "input mock | stats count=count(*) by col2"}
+                {:q "input mock name=\"chick-weight\" | stats avgWeight = avg(weight) by Chick"}
+                {:description "Expressions can be used to group by"
+                 :q "input mock name=\"chick-weight\" | stats avgWeight = avg(weight) by Chick, bucket(Time, 4)"}
+                {:q "input mock name=\"chick-weight\" | stats avgWeight = avg(weight) by Chick, Time = bucket(Time, 4)"}]}
+    {:name "sleep"
+     :type "statement"
+     :syntax ["sleep"
+              "sleep :expression"]
+     :description ["Delays execution of the query for a given number of milliseconds.  Defaults to 1000 milliseconds if no argument is given."]
+     :examples [{:q "input mock | sleep 5000"}]}
+    {:name "sample"
+     :type "statement"
+     :syntax ["sample :expr"]
+     :description ["Returns a sample of a given size from the current dataset.  The sample size can be either smaller or larger than the current dataset."]
+     :examples [{:description "Selecting a sample"
+                 :q "input mock n=100 | sample 10"}
+                {:description "Generating a larger sample from a smaller dataset"
+                 :q "input mock n=10 | sample 100"}]}
+    {:name "benchmark"
+     :type "statement"
+     :syntax ["benchmark :expr [:options]"
+              "bench :expr [:options]"]
+     :description ["Benchmarks a query and returns a single row of the results.  The query will be run multiple times and includes a warm-up period for the JIT compiler and forced GC before and after testing."
+                   "Various options are available to customize the benchmark, but defaults will be used if not provided.  The values used will be returned as a map in the \"options\" column."]
+     :examples [{:description "Benchmarking a query with default options"
+                 :q "benchmark \"input mock\""}
+                {:description "Providing a sample size"
+                 :q "bench \"input mock | head 1\" samples=20"}
+                {:description "Projecting the performance results for each sample"
+                 :q "benchmark \"input mock\" | project first(performance)"}
+                {:description "Projecting the text summary of the benchmark"
+                 :q "benchmark \"set @x = random()\" | project split(first(summary), \"\\n\")"}]}
+    {:name "pivot"
+     :type "statement"
+     :description ["Increases the number of columns in the current dataset by \"pivoting\" values of one or more columns into additional columns. For example, unique values in a column \"type\" can be converted into separate columns, with the values attributable to each type as their contents."]
+     :syntax ["pivot :value [, :value ...] per :expression [, :expression ...] by :group-by [, :group-by ...]"
+              "pivot :identifier=:value [, identifier=:value ...] per :expression [, :expression ...] by :group-by [, :group-by ...]"]
+     :related ["statement:unpivot"]}
+    {:name "unpivot"
+     :type "statement"
+     :syntax ["unpivot :value per :column by :group-by [, :group-by ...]"]
+     :description ["Reduces the number of columns in the current dataset by \"unpivoting\" them into rows of a single column.  This is the inverse operation of the pivot statement."]
+     :examples [{:q "input http uri=\"http://pastebin.com/raw.php?i=YGN7gWWG\" parser=\"json\" | unpivot CrimesCommitted per Type by Year, Population"}]
+     :related ["statement:pivot"]}
+    {:name "project"
+     :type "statement"
+     :syntax ["project :expression"]
+     :description ["Replaces the current dataset with the result of an expression. The expression must be either a list or a single map which will be wrapped in a list automatically."
+                   "Projecting a list of maps replaces the entire dataset verbatim. If the list does not contain maps, each value will be stored in a new column called \"value\"."
+                   "Can be useful when parsing data from a string."]
+     :examples [{:description "With a list of maps"
+                 :q "input mock | project [{x:1, y:1},{x:2, y:2}]"}
+                {:description "With a list of numbers"
+                 :q "input mock | project [4, 8, 15, 16, 23, 42] | stats avg = avg(value)"}
+                {:description "From a variable"
+                 :q "input mock | x = [{x:1, y:1},{x:2, y:2}] | project first(x)"}
+                {:description "With a single map"
+                 :q "input mock | project {a: 1, b: 2, c: 3}"}
+                {:description "With a JSON string"
+                 :q "input mock | x = '[{\"x\":1, \"y\":1},{\"x\":2, \"y\":2}]' | project parsejson(first(x))"}
+                {:description "With a CSV string"
+                 :q "input http uri=\"http://pastebin.com/raw.php?i=s6xmiNzx\" | project parsecsv(first(body), { strict: true, delimiter: \",\" })"}]}
+    {:name "join"
+     :type "statement"
+     :syntax ["[inner] join [:left-alias], :dataset-or-query on :expression [, :expression, ...]"
+              "left [outer] join [:left-alias], :dataset-or-query on :expression [, :expression, ...]"
+              "right [outer] join [:left-alias], :dataset-or-query on :expression [, :expression, ...]"
+              "full [outer] join [:left-alias], :dataset-or-query on :expression [, :expression, ...]"
+              "cross join :dataset-or-query"]
+     :description ["Joins the current dataset with another dataset. The join statement takes the current dataset as the left dataset, and either accepts the name of a dataset in the context or an inline query in parentheses."
+                   "Join types available: Inner, Left Outer (Left), Right Outer (Right), Full Outer (Full), and Cross Join.  If no join type is specified, inner join will be assumed."
+                   "The joined dataset is the output of this statement.  Columns from joined rows will be merged, with preference given to the value in the Left dataset."]
+     :examples [{:description "Inner join"
+                 :q "project [{ id: 1, type: \"a\" }, { id: 2, type: \"b\" }] | temp types; project [{ name: \"x\", typeId: 1 }, { name: \"y\", typeId: 2 }] | inner join types on typeId == types.id"}
+                {:description "Left outer join"
+                 :q "project [{ id: 1, type: \"a\" }, { id: 2, type: \"b\" }] | temp types; project [{ name: \"x\", typeId: 1 }, { name: \"y\", typeId: 2 }, { name: \"z\", typeId: 3 }] | left outer join types on typeId == types.id"}
+                {:description "Right outer join"
+                 :q "project [{ id: 1, type: \"a\" }, { id: 2, type: \"b\" }, { id: 3, type: \"c\" }] | temp types; project [{ name: \"x\", typeId: 1 }, { name: \"y\", typeId: 2 }, { name: \"z\", typeId: 1 }] | right outer join types on typeId == types.id"}
+                {:description "Full outer join"
+                 :q "project [{ id: 1, type: \"a\" }, { id: 2, type: \"b\" }, { id: 3, type: \"c\" }] | temp types; project [{ name: \"x\", typeId: 1 }, { name: \"y\", typeId: 2 }, { name: \"z\", typeId: 4 }] | full outer join types on typeId == types.id"}
+                {:description "Cross join"
+                 :q "project [{ id: 1, type: \"a\" }, { id: 2, type: \"b\" }] | temp types; project [{ name: \"x\" }, { name: \"y\" }] | cross join types"}]
+     :related ["statement:inner join" "statement:left outer join" "statement:right outer join" "statement:full outer join" "statement:cross join"]}
+    {:name "inner join"
+     :type "statement"
+     :syntax ["[inner] join [:left-alias], :dataset-or-query on :expression [, :expression, ...]"]
+     :description ["Inner join is a type of join which requires each row in the joined datasets to satisfy a join predicate."]
+     :examples [{:description "Inner join"
+                 :q "project [{ id: 1, type: \"a\" }, { id: 2, type: \"b\" }] | temp types; project [{ name: \"x\", typeId: 1 }, { name: \"y\", typeId: 2 }] | inner join types on typeId == types.id"}]
+     :related ["statement:join" "statement:left outer join" "statement:right outer join" "statement:full outer join" "statement:cross join"]}
+    {:name "left outer join"
+     :type "statement"
+     :syntax ["left [outer] join [:left-alias], :dataset-or-query on :expression [, :expression, ...]"]
+     :description ["Left Outer join is a type of join which always includes all rows of the left-hand dataset, even if they do not satisfy the join predicate."]
+     :examples [{:description "Left outer join"
+                 :q "project [{ id: 1, type: \"a\" }, { id: 2, type: \"b\" }] | temp types; project [{ name: \"x\", typeId: 1 }, { name: \"y\", typeId: 2 }, { name: \"z\", typeId: 3 }] | left outer join types on typeId == types.id"}]
+     :related ["statement:join" "statement:inner join" "statement:right outer join" "statement:full outer join" "statement:cross join"]}
+    {:name "right outer join"
+     :type "statement"
+     :syntax ["right [outer] join [:left-alias], :dataset-or-query on :expression [, :expression, ...]"]
+     :description ["Right Outer join is a type of join which always includes all rows of the right-hand dataset, even if they do not satisfy the join predicate."]
+     :examples [{:description "Right outer join"
+                 :q "project [{ id: 1, type: \"a\" }, { id: 2, type: \"b\" }, { id: 3, type: \"c\" }] | temp types; project [{ name: \"x\", typeId: 1 }, { name: \"y\", typeId: 2 }, { name: \"z\", typeId: 1 }] | right outer join types on typeId == types.id"}]
+     :related ["statement:join" "statement:inner join" "statement:left outer join" "statement:full outer join" "statement:cross join"]}
+    {:name "full outer join"
+     :type "statement"
+     :syntax ["full [outer] join [:left-alias], :dataset-or-query on :expression [, :expression, ...]"]
+     :description ["Full Outer join is a type of join which combines the effects of both left and right outer join.  All rows from both left and right datasets will be included in the result."]
+     :examples [{:description "Full outer join"
+                 :q "project [{ id: 1, type: \"a\" }, { id: 2, type: \"b\" }, { id: 3, type: \"c\" }] | temp types; project [{ name: \"x\", typeId: 1 }, { name: \"y\", typeId: 2 }, { name: \"z\", typeId: 4 }] | full outer join types on typeId == types.id"}]
+     :related ["statement:join" "statement:inner join" "statement:left outer join" "statement:right outer join" "statement:cross join"]}
+    {:name "cross join"
+     :type "statement"
+     :syntax ["cross join [:left-alias], :dataset-or-query"]
+     :description ["Cross join is a type of join which returns the cartesian product of rows from both datasets."]
+     :examples [{:description "Cross join"
+                 :q "project [{ id: 1, type: \"a\" }, { id: 2, type: \"b\" }] | temp types; project [{ name: \"x\" }, { name: \"y\" }] | cross join types"}]
+     :related ["statement:join" "statement:inner join" "statement:left outer join" "statement:right outer join" "statement:full outer join"]}))

--- a/packages/parsec/src/parsec/docs/symbols.clj
+++ b/packages/parsec/src/parsec/docs/symbols.clj
@@ -1,0 +1,32 @@
+;; Copyright 2022 Expedia, Inc.
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     https://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns parsec.docs.symbols)
+
+(def tokens
+  '({:name ";"
+     :altName "query separator"
+     :type "symbol"
+     :syntax ["query1; query2", "query1; query2; query3 ..."]
+     :description "The query separator is used to separate two distinct Parsec queries. The queries will be executed sequentially with a shared context."
+     :examples [{:q "input mock; input mock"}]}
+    {:name "/* */"
+     :altName "comment block"
+     :type "symbol"
+     :syntax ["/* ... */"]
+     :description ["Comments in Parsec follow the general C style /* ... */ block comment form and are ignored by the parser.
+                    
+                    Nested comment blocks are supported, provided they are balanced."]
+     :examples [{:q "/* My query */ input mock"}
+                {:q "input mock | /* filter col1 == 1 | */ sort col1 desc"}]}))

--- a/packages/parsec/src/parsec/input/docs.clj
+++ b/packages/parsec/src/parsec/input/docs.clj
@@ -1,0 +1,33 @@
+;; Copyright 2022 Expedia, Inc.
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     https://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns parsec.input.docs
+  (:require [parsec.docs.symbols :as symbols]
+            [parsec.docs.literals :as literals]
+            [parsec.docs.operators :as operators]
+            [parsec.docs.statements :as statements]))
+
+; Options:
+; TBD
+
+(defn input-transform
+  "Returns documentation data for Parsec"
+  [_options]
+  (fn [context]
+    (let [docs (concat literals/tokens
+                       operators/tokens
+                       statements/tokens
+                       symbols/tokens)]
+
+      (assoc context :current-dataset docs))))

--- a/packages/parsec/src/parsec/input/mock.clj
+++ b/packages/parsec/src/parsec/input/mock.clj
@@ -1,0 +1,56 @@
+;; Copyright 2022 Expedia, Inc.
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     https://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns parsec.input.mock
+  (:require [incanter.datasets :as datasets]
+            [parsec.helpers :refer [eval-expression-without-row
+                                    incanter-to-maplist to-number]]))
+
+(def mock-dataset
+  '({:col1 1, :col2 2, :col3 3, :col4 4}
+     {:col1 2, :col2 2, :col3 3, :col4 3}
+     {:col1 3, :col2 2, :col3 5, :col4 2}
+     {:col1 4, :col2 5, :col3 5, :col4 1}
+     {:col1 5, :col2 5, :col3 3, :col4 0}))
+
+; Options:
+; :name
+; :n
+
+(defn input-transform
+  "Returns a mock dataset"
+  [options]
+  (fn [context]
+      (let [options' (eval-expression-without-row options context)
+            n (to-number (options' :n))
+            name (options' :name)]
+        (let [mock (cond
+                     (not (nil? name))
+                     ;; Incanter dataset
+                     (incanter-to-maplist (datasets/get-dataset (keyword (:name options')) :incanter-home (:incanterHome options')))
+
+                     ;; Large mock dataset with N rows
+                     (not (nil? n))
+                     (map (fn [i] {:col1 i,
+                                   :col2 (- n i),
+                                   :col3 (mod i 5),
+                                   :col4 (mod i 8)
+                                   :col5 (Math/cos i)}) (range n))
+
+
+                     ;; Else default mock dataset
+                     :else
+                     mock-dataset)]
+
+          (assoc context :current-dataset mock)))))

--- a/packages/parsec/test/parsec/input/mock_input_test.clj
+++ b/packages/parsec/test/parsec/input/mock_input_test.clj
@@ -1,0 +1,25 @@
+(ns parsec.input.mock-input-test
+  (:require [clojure.test :refer :all]
+            [parsec.helpers :refer :all]
+            [parsec.test-helpers :refer :all]
+            [parsec.test-datasets :refer :all]
+            [parsec.parser :refer :all]
+            [parsec.input.mock :refer [input-transform mock-dataset]]))
+
+(deftest mock-input-transform-test
+  (testing "mock input with no option"
+    (let [result (:current-dataset ((input-transform {}) nil))]
+      (is (= 5 (count result)))
+      (is (= mock-dataset result))))
+
+  (testing "mock N input with 1"
+    (let [result (:current-dataset ((input-transform {:n 1}) nil))]
+      (is (= 1 (count result)))))
+
+  (testing "mock N input with 20"
+    (let [result (:current-dataset ((input-transform {:n 20}) nil))]
+      (is (= 20 (count result)))))
+
+  (testing "mock N input with 20"
+    (let [result (:current-dataset ((input-transform {:n "20"}) nil))]
+      (is (= 20 (count result))))))

--- a/packages/parsec/test/parsec/statements/input_statement_test.clj
+++ b/packages/parsec/test/parsec/statements/input_statement_test.clj
@@ -2,67 +2,40 @@
   (:require [clojure.test :refer :all]
             [parsec.test-helpers :refer :all]
             [parsec.test-datasets :refer :all]
-            [parsec.parser :refer :all]
-            [parsec.statements :refer [input-statement mock-dataset]]))
+            [parsec.parser :refer :all]))
 
 (deftest input-statement-parser-test
   (testing-parser!
-    "with no type" :input-statement "input")
+   "with no type" :input-statement "input")
 
   (testing-parser!
-    "with assignment" :input-statement "input=mock")
+   "with assignment" :input-statement "input=mock")
 
   (testing-parser!
-    "with quoted source type" :input-statement "input 'mock'")
+   "with quoted source type" :input-statement "input 'mock'")
 
   (testing-parser!
-    "with quoted source type" :input-statement "input [mock]")
+   "with quoted source type" :input-statement "input [mock]")
 
   (testing-parser!
-    "with quoted source type" :input-statement "input \"mock\"")
+   "with quoted source type" :input-statement "input \"mock\"")
 
   (testing-parser
-    "with no options" :input-statement
-    "input mock" [:input-statement :mock [:function :tolowercasemap]])
+   "with no options" :input-statement
+   "input mock" [:input-statement :mock [:function :tolowercasemap]])
 
   (testing-parser
-    "with one option" :input-statement
-    "input mocklarge n='20'" [:input-statement :mocklarge [:function :tolowercasemap "n" [:expression "20"]]])
+   "with one option" :input-statement
+   "input mocklarge n='20'" [:input-statement :mocklarge [:function :tolowercasemap "n" [:expression "20"]]])
 
   (testing-parser
-    "with two options" :input-statement
-    "input mock n='20' m=40" [:input-statement :mock [:function :tolowercasemap "n" [:expression "20"] "m" [:expression 40]]])
+   "with two options" :input-statement
+   "input mock n='20' m=40" [:input-statement :mock [:function :tolowercasemap "n" [:expression "20"] "m" [:expression 40]]])
 
   (testing-parser
-    "with three options" :input-statement
-    "input test x=\"1\" y=2 z=true" [:input-statement :test [:function :tolowercasemap "x" [:expression "1"] "y" [:expression 2] "z" [:expression true]]])
+   "with three options" :input-statement
+   "input test x=\"1\" y=2 z=true" [:input-statement :test [:function :tolowercasemap "x" [:expression "1"] "y" [:expression 2] "z" [:expression true]]])
 
   (testing-parser
-    "with three options and commas" :input-statement
-    "input test x=\"1\",y=2,z=true" [:input-statement :test [:function :tolowercasemap "x" [:expression "1"] "y" [:expression 2] "z" [:expression true]]]))
-
-(deftest input-statement-test
-  (testing-statement
-    "mock input"
-    (input-statement :mock {})
-    nil
-    mock-dataset)
-
-  (testing "mock input with no option"
-    (let [result (:current-dataset ((input-statement :mock {}) nil))]
-      (is (= 5 (count result)))))
-
-  (testing "mock N input with 1"
-    (let [result (:current-dataset ((input-statement :mock { :n 1 }) nil))]
-      (is (= 1 (count result)))))
-
-  (testing "mock N input with 20"
-    (let [result (:current-dataset ((input-statement :mock { :n 20 }) nil))]
-      (is (= 20 (count result)))))
-
-  (testing "mock N input with 20"
-    (let [result (:current-dataset ((input-statement :mock { :n "20"}) nil))]
-      (is (= 20 (count result)))))
-
-  (testing "invalid input"
-    (is (thrown? Exception (input-statement "bogus-input" {})))))
+   "with three options and commas" :input-statement
+   "input test x=\"1\",y=2,z=true" [:input-statement :test [:function :tolowercasemap "x" [:expression "1"] "y" [:expression 2] "z" [:expression true]]]))


### PR DESCRIPTION
Creates a new input type `docs` which will return Parsec API documentation.  Started converting documentation over from legacy website.